### PR TITLE
Fixed slow file Upload

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -12,11 +12,6 @@ import shutil
 import config
 
 
-def delete_temp_image_file(img_id):
-    time.sleep(60)
-    os.remove('./static/verified/images/' + img_id + '.jpg')
-
-
 def retrieve_image_from_database(img_id):
     # get an image based on it's 'certify code'
     client = pymongo.MongoClient(config.MONGODB_URI, connectTimeoutMS=30000)

--- a/generate.py
+++ b/generate.py
@@ -27,7 +27,6 @@ def retrieve_image_from_database(img_id):
         verified_img_file = open('./static/verified/images/' + img_id + '.jpg', 'wb')
         verified_img_file.write(retrieved_img)
         img_location = 'verified/images/' + img_id + '.jpg'
-        delete_tmp_img_after_60_sec = threading.Thread(target=delete_temp_image_file, args=(img_id,))
         return True
     else:
         return False
@@ -39,8 +38,6 @@ def add_to_image_database(image, img_id):
     database = client.certify
     fs = gridfs.GridFS(database)
     fs.put(image, _id=img_id)
-    time.sleep(3)
-    os.remove('./static/verified/images/' + img_id + '_downsized' + '.jpg')
 
 
 def addToDatabase(listData):

--- a/generate.py
+++ b/generate.py
@@ -12,6 +12,11 @@ import shutil
 import config
 
 
+def delete_temp_image_file(img_id):
+    time.sleep(60)
+    os.remove('./static/verified/images/' + img_id + '.jpg')
+
+
 def retrieve_image_from_database(img_id):
     # get an image based on it's 'certify code'
     client = pymongo.MongoClient(config.MONGODB_URI, connectTimeoutMS=30000)
@@ -22,6 +27,7 @@ def retrieve_image_from_database(img_id):
         verified_img_file = open('./static/verified/images/' + img_id + '.jpg', 'wb')
         verified_img_file.write(retrieved_img)
         img_location = 'verified/images/' + img_id + '.jpg'
+        delete_tmp_img_after_60_sec = threading.Thread(target=delete_temp_image_file, args=(img_id,))
         return True
     else:
         return False

--- a/generate.py
+++ b/generate.py
@@ -4,6 +4,7 @@ import sys
 from hashids import Hashids
 from datetime import datetime, date
 import time
+import threading
 import os
 import pymongo
 import gridfs
@@ -28,11 +29,12 @@ def retrieve_image_from_database(img_id):
 
 def add_to_image_database(image, img_id):
     # Saves a given image to the database with the 'certify code' as its ID
-
     client = pymongo.MongoClient(config.MONGODB_URI, connectTimeoutMS=30000)
     database = client.certify
     fs = gridfs.GridFS(database)
     fs.put(image, _id=img_id)
+    time.sleep(3)
+    os.remove('./static/verified/images/' + img_id + '_downsized' + '.jpg')
 
 
 def addToDatabase(listData):
@@ -127,8 +129,10 @@ class Create:
                 downsized_img = img.resize((500, img_size_on_y), Image.LANCZOS)
                 downsized_img.save('./static/verified/images/' + data["Certify"][i] + '_downsized' + '.jpg')
                 database_image = open('./static/verified/images/' + data["Certify"][i] + '_downsized' +'.jpg', 'rb')
-                add_to_image_database(database_image, data["Certify"][i])
-                os.remove('./static/verified/images/' + data["Certify"][i] + '_downsized' + '.jpg')
+                background_thread = threading.Thread(target=add_to_image_database,
+                                                     args=(database_image, data["Certify"][i]))
+                background_thread.start()
+
             
             #save for downloading
             folder = './static/temp/download/download_' + str(self.ts)


### PR DESCRIPTION
Fixed slow file upload through multi threading. The deletion of the uploaded (downsized) images was causing issues, so the entire thing had to be slowed down by the `time.sleep(3)` line. As it happens after the file upload, it shouldn't influence the UX of the sit.
Furthermore I added a short mechanism to remove the temporary verification images as we were previously storing them indefinitely, which isn't all to effective (since it also utilities threading, I chose to include it into this pull request). 